### PR TITLE
Vk for sb 0 16 latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ features = ["macros"]
 test-log = "*"
 
 [patch.crates-io]
-symbolica = { git = "https://github.com/benruijl/symbolica", rev = "57f25f34928ca667bd5889d94ed616d15e2ad94f" }
+#symbolica = { git = "https://github.com/benruijl/symbolica", rev = "dc423c78a69bb4127947b433ce4b4228edc70b54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ features = ["macros"]
 
 [dev-dependencies]
 test-log = "*"
+
+[patch.crates-io]
+symbolica = { git = "https://github.com/benruijl/symbolica", rev = "57f25f34928ca667bd5889d94ed616d15e2ad94f" }

--- a/examples/oneloop_evaluation.rs
+++ b/examples/oneloop_evaluation.rs
@@ -12,7 +12,12 @@ fn main() {
     .unwrap();
 
     let mut integral = symbolica::parse!(
-        "(vk::k(3,mink4(4,11))*vk::k(3,mink4(4,22))+vk::k(3,mink4(4,77))*vk::p(8,mink4(4,77)))*vk::topo(\
+        "(
+              vk::k(3,mink4(4,11))*vk::k(3,mink4(4,22))
+            + vk::k(3,mink4(4,77))*vk::p(8,mink4(4,77))
+            + vk::p(1,mink4(4,77))*vk::p(2,mink4(4,77))
+            + vk::p(1,mink4(4,99))*vk::p(2,mink4(4,101))
+        )*vk::topo(\
         vk::prop(9,vk::edge(66,66),vk::k(3),MUVsq,1)\
     )"
     )
@@ -48,19 +53,43 @@ fn main() {
         Vakint::partial_numerical_evaluation(&vakint.settings, integral.as_view(), &params, None);
     println!("Partial eval:\n{}\n", numerical_partial_eval);
 
+    let externals = vakint.externals_from_f64(
+        &(1..=2)
+            .map(|i| {
+                (
+                    i,
+                    (
+                        0.17 * ((i + 1) as f64),
+                        0.4 * ((i + 2) as f64),
+                        0.3 * ((i + 3) as f64),
+                        0.12 * ((i + 4) as f64),
+                    ),
+                )
+            })
+            .collect(),
+    );
+
     params.insert(
         "vk::g(oneloop_evaluation::mink4(4,22),oneloop_evaluation::mink4(4,11))".into(),
+        vakint.settings.real_to_prec("1.0"),
+    );
+    params.insert(
+        "vk::p(1,oneloop_evaluation::mink4(4,99))".into(),
+        vakint.settings.real_to_prec("1.0"),
+    );
+    params.insert(
+        "vk::p(2,oneloop_evaluation::mink4(4,101))".into(),
         vakint.settings.real_to_prec("1.0"),
     );
     let numerical_full_eval = Vakint::full_numerical_evaluation_without_error(
         &vakint.settings,
         integral.as_view(),
         &params,
-        None,
+        Some(&externals),
     )
     .unwrap();
     println!(
-        "Full eval (metric substituted with 1):\n{}\n",
+        "Full eval (tensor structures left all substituted with 1):\n{}\n",
         numerical_full_eval
     );
 }

--- a/examples/oneloop_evaluation.rs
+++ b/examples/oneloop_evaluation.rs
@@ -12,7 +12,7 @@ fn main() {
     .unwrap();
 
     let mut integral = symbolica::parse!(
-        "(vk::k(3,11)*vk::k(3,22)+vk::k(3,77)*vk::p(8,77))*vk::topo(\
+        "(vk::k(3,mink4(4,11))*vk::k(3,mink4(4,22))+vk::k(3,mink4(4,77))*vk::p(8,mink4(4,77)))*vk::topo(\
         vk::prop(9,vk::edge(66,66),vk::k(3),MUVsq,1)\
     )"
     )
@@ -48,7 +48,10 @@ fn main() {
         Vakint::partial_numerical_evaluation(&vakint.settings, integral.as_view(), &params, None);
     println!("Partial eval:\n{}\n", numerical_partial_eval);
 
-    params.insert("vk::g(11,22)".into(), vakint.settings.real_to_prec("1.0"));
+    params.insert(
+        "vk::g(oneloop_evaluation::mink4(4,22),oneloop_evaluation::mink4(4,11))".into(),
+        vakint.settings.real_to_prec("1.0"),
+    );
     let numerical_full_eval = Vakint::full_numerical_evaluation_without_error(
         &vakint.settings,
         integral.as_view(),

--- a/src/fmft.rs
+++ b/src/fmft.rs
@@ -451,7 +451,8 @@ impl Vakint {
             vakint.settings.temporary_directory.clone(),
         )?;
 
-        let processed_form_result = self.process_form_output(form_result, vec![])?;
+        let processed_form_result =
+            self.process_form_output(form_result, vec![], HashMap::new())?;
         let mut evaluated_integral = fmft.process_fmft_form_output(processed_form_result)?;
         debug!(
             "{}: raw result from FORM:\n{}",

--- a/src/fmft.rs
+++ b/src/fmft.rs
@@ -451,7 +451,7 @@ impl Vakint {
             vakint.settings.temporary_directory.clone(),
         )?;
 
-        let processed_form_result = self.process_form_output(form_result)?;
+        let processed_form_result = self.process_form_output(form_result, vec![])?;
         let mut evaluated_integral = fmft.process_fmft_form_output(processed_form_result)?;
         debug!(
             "{}: raw result from FORM:\n{}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3091,8 +3091,8 @@ impl Vakint {
             let mut old_processed_numerator = processed_numerator.clone();
             loop {
                 let arc_mutex_lorentz_indices_sent = arc_mutex_lorentz_indices.clone();
-                let dot_product_transformer =
-                    Transformer::Map(Box::new(move |a_in: AtomView, a_out: &mut Atom| {
+                let dot_product_transformer = Transformer::Map(Box::new(
+                    move |a_in: AtomView, _state: _, a_out: &mut Atom| {
                         if let AtomView::Fun(s) = a_in {
                             let a_in = s
                                 .to_slice()
@@ -3118,7 +3118,8 @@ impl Vakint {
                         };
 
                         Ok(())
-                    }));
+                    },
+                ));
 
                 processed_numerator = old_processed_numerator
                     .replace(dot_product_matcher.to_pattern())

--- a/src/matad.rs
+++ b/src/matad.rs
@@ -410,6 +410,11 @@ impl Vakint {
         };
 
         let mut numerator = Vakint::convert_to_dot_notation(input_numerator);
+
+        // println!("Numerator before processing: {}", numerator);
+        let mut indices = Vakint::identify_vector_indices(numerator.as_view())?;
+        // for (i, user_i) in indices.iter().enumerate() {}
+
         numerator = numerator
             .replace(Atom::new_var(muv_sq_symbol).to_pattern())
             .with(vk_parse!("M^2").unwrap().to_pattern());
@@ -564,7 +569,8 @@ impl Vakint {
             vakint.settings.temporary_directory.clone(),
         )?;
 
-        let processed_form_result = self.process_form_output(form_result, vec![])?;
+        let processed_form_result =
+            self.process_form_output(form_result, indices, HashMap::new())?;
         let mut evaluated_integral = matad.process_matad_form_output(processed_form_result)?;
         debug!(
             "{}: raw result from FORM:\n{}",

--- a/src/matad.rs
+++ b/src/matad.rs
@@ -564,7 +564,7 @@ impl Vakint {
             vakint.settings.temporary_directory.clone(),
         )?;
 
-        let processed_form_result = self.process_form_output(form_result)?;
+        let processed_form_result = self.process_form_output(form_result, vec![])?;
         let mut evaluated_integral = matad.process_matad_form_output(processed_form_result)?;
         debug!(
             "{}: raw result from FORM:\n{}",

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -58,7 +58,7 @@ pub static S: LazyLock<VakintSymbols> = LazyLock::new(|| VakintSymbols {
         format!("{}::vkdot",crate::NAMESPACE);  Symmetric, Linear
     )
     .unwrap(),
-    g: symbol!(format!("{}::METRIC_SYMBOL",crate::NAMESPACE); Symmetric).unwrap(),
+    g: symbol!(format!("{}::{}",crate::NAMESPACE,METRIC_SYMBOL); Symmetric).unwrap(),
     x: vk_symbol!("x"),
     y: vk_symbol!("y"),
     xa: Atom::new_var(vk_symbol!("xa")),

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -16,6 +16,7 @@ pub struct VakintSymbols {
     pub dot: Symbol,
     pub vkdot: Symbol,
     pub g: Symbol,
+    pub g_form: Symbol,
     pub x: Symbol,
     pub y: Symbol,
     pub xa: Atom,
@@ -59,6 +60,7 @@ pub static S: LazyLock<VakintSymbols> = LazyLock::new(|| VakintSymbols {
     )
     .unwrap(),
     g: symbol!(format!("{}::{}",crate::NAMESPACE,METRIC_SYMBOL); Symmetric).unwrap(),
+    g_form: symbol!(format!("{}::g",crate::NAMESPACE); Symmetric).unwrap(),
     x: vk_symbol!("x"),
     y: vk_symbol!("y"),
     xa: Atom::new_var(vk_symbol!("xa")),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,11 @@ pub(crate) mod vakint_macros {
     }
     macro_rules! vk_symbol {
         ($s: expr) => {{
-            symbolica::symbol!(format!("{}::{}", crate::NAMESPACE, $s))
+            if format!("{}", $s).starts_with(format!("{}::", crate::NAMESPACE).as_str()) {
+                symbolica::symbol!($s)
+            } else {
+                symbolica::symbol!(format!("{}::{}", crate::NAMESPACE, $s))
+            }
         }};
     }
 

--- a/templates/run_alphaloop_integral_evaluation.txt
+++ b/templates/run_alphaloop_integral_evaluation.txt
@@ -7,7 +7,7 @@ Auto S n,x,m,t,cMi,log,z,ALARM;
 CF rat,map,uvprop,g(s),tmps(s),dot;
 
 Auto I s=4,mu=D;
-CF vx,rat,map,uvprop,g(s),vxs(s),tmps(s),dot;
+CF vx,rat,map,uvprop,g(s),vxs(s),tmps(s),dot,vec,vec1,gamma;
 CT opengammastring;
 
 Polyratfun rat;

--- a/tests/integral_evaluation_analytic_tests.rs
+++ b/tests/integral_evaluation_analytic_tests.rs
@@ -197,13 +197,13 @@ fn test_integrate_1l_cross_product_with_additional_symbols_numerator() {
         VakintSettings{number_of_terms_in_epsilon_expansion: 5, integral_normalization_factor: LoopNormalizationFactor::MSbar,..VakintSettings::default()},
         EvaluationOrder::analytic_only(),
         vakint_parse!(
-            "(A*k(1,11)*p(1,11)*k(1,12)*p(1,12)+B)*topo(\
+            "(user_space::A*k(1,11)*p(1,11)*k(1,12)*p(1,12)+user_space::B)*topo(\
                 prop(1,edge(1,1),k(1),muvsq,2)\
             )"
         )
         .unwrap()
         .as_view(),
-        params_from_f64(&[("muvsq".into(), 1.0), ("mursq".into(), 1.0), ("A".into(), 3.0), ("B".into(), 4.0)].iter().cloned().collect(),
+        params_from_f64(&[("muvsq".into(), 1.0), ("mursq".into(), 1.0), ("user_space::A".into(), 3.0), ("user_space::B".into(), 4.0)].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         externals_from_f64(
         &(1..=1)
@@ -362,9 +362,9 @@ fn test_integrate_3l_rank_4_additional_symbols_numerator() {
         EvaluationOrder::alphaloop_only(),
         vakint_parse!(
             "(
-                  A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
-                + B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
-                + C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
+                  user_space::A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
+                + user_space::B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
+                + user_space::C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
              )
             *topo(\
                  prop(1,edge(1,2),k(1),muvsq,1)\
@@ -377,7 +377,7 @@ fn test_integrate_3l_rank_4_additional_symbols_numerator() {
         ).unwrap().as_view(),
         params_from_f64(&[
             ("muvsq".into(), 1.0), ("mursq".into(), 2.0),
-            ("A".into(), 5.0), ("B".into(), 7.0), ("C".into(), 11.0)
+            ("user_space::A".into(), 5.0), ("user_space::B".into(), 7.0), ("user_space::C".into(), 11.0)
             ].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         externals_from_f64(
@@ -442,9 +442,9 @@ fn test_integrate_3l_rank_4_matad_additional_symbols_numerator() {
         EvaluationOrder::matad_only(Some(MATADOptions {direct_numerical_substition: true,..MATADOptions::default()})),
         vakint_parse!(
             "(
-                  A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
-                + B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
-                + C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
+                  user_space::A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
+                + user_space::B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
+                + user_space::C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
              )
             *topo(\
                  prop(1,edge(1,2),k(1),muvsq,1)\
@@ -457,7 +457,7 @@ fn test_integrate_3l_rank_4_matad_additional_symbols_numerator() {
         ).unwrap().as_view(),
         params_from_f64(&[
             ("muvsq".into(), 1.0), ("mursq".into(), 2.0),
-            ("A".into(), 5.0), ("B".into(), 7.0), ("C".into(), 11.0)
+            ("user_space::A".into(), 5.0), ("user_space::B".into(), 7.0), ("user_space::C".into(), 11.0)
             ].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         externals_from_f64(
@@ -595,9 +595,9 @@ fn test_integrate_4l_h_rank_4_additional_symbols_numerator() {
         EvaluationOrder(vec![EvaluationMethod::FMFT(FMFTOptions {..FMFTOptions::default()} )]),
         vakint_parse!(
             "(
-                  A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
-                + B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
-                + C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
+                  user_space::A*k(1,11)*k(2,11)*k(1,22)*k(2,22)
+                + user_space::B*p(1,11)*k(3,11)*k(3,22)*p(2,22)
+                + user_space::C*p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
              )*topo(\
                  prop(1,edge(5,1),k(1),muvsq,1)\
                 *prop(2,edge(2,6),k(2),muvsq,1)\
@@ -611,7 +611,7 @@ fn test_integrate_4l_h_rank_4_additional_symbols_numerator() {
             )"
         ).unwrap().as_view(),
         // Masses chosen equal on purpose here so as to have a reliable target analytical result
-        params_from_f64(&[("muvsq".into(), 3.0), ("mursq".into(), 5.0), ("A".into(), 5.0), ("B".into(), 7.0), ("C".into(), 11.0)].iter().cloned().collect(),
+        params_from_f64(&[("muvsq".into(), 3.0), ("mursq".into(), 5.0), ("user_space::A".into(), 5.0), ("user_space::B".into(), 7.0), ("user_space::C".into(), 11.0)].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         externals_from_f64(
         &(1..=2)
@@ -975,9 +975,9 @@ fn test_integrate_4l_clover_with_numerator() {
         EvaluationOrder(vec![EvaluationMethod::FMFT(FMFTOptions {..FMFTOptions::default()} )]),
         vakint_parse!(
             "( 
-                  A * k(1,11)*k(2,11)*k(1,22)*k(2,22)
-                + B * p(1,11)*k(3,11)*k(3,22)*p(2,22)
-                + C * p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
+                  user_space::A * k(1,11)*k(2,11)*k(1,22)*k(2,22)
+                + user_space::B * p(1,11)*k(3,11)*k(3,22)*p(2,22)
+                + user_space::C * p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
              )*topo(
                 prop(1, edge(1, 1), k(1), muvsq, 2)*\
                 prop(2, edge(1, 1), k(2), muvsq, 1)*\
@@ -986,7 +986,7 @@ fn test_integrate_4l_clover_with_numerator() {
             )"
         ).unwrap().as_view(),
         // Masses chosen equal on purpose here so as to have a reliable target analytical result
-        params_from_f64(&[("muvsq".into(), 0.3), ("mursq".into(), 0.7), ("A".into(), 3.0), ("B".into(), 4.0), ("C".into(), 5.0)].iter().cloned().collect(),
+        params_from_f64(&[("muvsq".into(), 0.3), ("mursq".into(), 0.7), ("user_space::A".into(), 3.0), ("user_space::B".into(), 4.0), ("user_space::C".into(), 5.0)].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         externals_from_f64(
         &(1..=2)

--- a/tests/integral_evaluation_freeform_tests.rs
+++ b/tests/integral_evaluation_freeform_tests.rs
@@ -29,21 +29,28 @@ fn test_integrate_1l_decorated_indices_alphaloop() {
         VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::MSbar,..VakintSettings::default()},
         EvaluationOrder::alphaloop_only(),
         parse!(
-            "( vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(8,user_space::mink4(4,77)) ) \
+            "( user_space::sigma(user_space::some_args)*vk::p(1,user_space::mink4(4,33))*vk::p(2,user_space::mink4(4,33))*vk::p(1,user_space::mink4(4,11))*vk::p(2,user_space::mink4(4,22))+vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(1,user_space::mink4(4,77)) ) \
              * vk::topo( vk::prop(9,vk::edge(66,66),vk::k(3),user_space::MUVsq,1 ))\
             ")
         .unwrap()
         .as_view(),
         params_from_f64(&[
             ("user_space::MUVsq".into(), 1.0), ("vk::mursq".into(), 1.0),
-            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0)
+            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(1,user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(2,user_space::mink4(4,22))".into(), 1.0),
+            ("user_space::sigma(user_space::some_args)".into(), 1.0),
             ].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
-        HashMap::default(),
+        externals_from_f64(
+        &(1..=2)
+            .map(|i| (i, (0.17*((i+1) as f64), 0.4*((i+2) as f64), 0.3*((i+3) as f64), 0.12*((i+4) as f64))))
+            .collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         vec![
-            (-1, ("0.0".into(), "2.467401100272339654708622749969".into()),),
-            (0,  ("0.0".into(), "-5.368458141238928322097907419453".into()),),
-            (1,  ("0.0".into(), "9.411704244710969435114178881646".into()),),
+            (-1, ("0.0".into(), "-36.79980696990178527744327373291".into()),),
+            (0,  ("0.0".into(), "99.70093613678094097571666372594".into()),),
+            (1,  ("0.0".into(), "-183.0878169087836963770976657747".into()),),
         ],
         N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
     );
@@ -57,22 +64,30 @@ fn test_integrate_1l_decorated_indices_matad() {
         VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::pySecDec,..VakintSettings::default()},
         EvaluationOrder::matad_only(None),
         parse!(
-            "( vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(8,user_space::mink4(4,77)) ) \
+            "( user_space::sigma(user_space::some_args)*vk::p(1,user_space::mink4(4,33))*vk::p(2,user_space::mink4(4,33))*vk::p(1,user_space::mink4(4,11))*vk::p(2,user_space::mink4(4,22))+vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(1,user_space::mink4(4,77)) ) \
              * vk::topo( vk::prop(9,vk::edge(66,66),vk::k(3),user_space::MUVsq,1 ))\
             ")
         .unwrap()
         .as_view(),
         params_from_f64(&[
             ("user_space::MUVsq".into(), 1.0), ("vk::mursq".into(), 1.0),
-            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0)
+            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(1,user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(2,user_space::mink4(4,22))".into(), 1.0),
+            ("user_space::sigma(user_space::some_args)".into(), 1.0),
             ].iter().cloned().collect(),
             N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
-        HashMap::default(),
+        externals_from_f64(
+        &(1..=2)
+            .map(|i| (i, (0.17*((i+1) as f64), 0.4*((i+2) as f64), 0.3*((i+3) as f64), 0.12*((i+4) as f64))))
+            .collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
         vec![
-            (-1, ("0.0".into(), "2.467401100272339654708622749969".into()),),
-            (0,  ("0.0".into(), "-5.368458141238928322097907419453".into()),),
-            (1,  ("0.0".into(), "9.411704244710969435114178881646".into()),),
+            (-1, ("0.0".into(), "-36.79980696990178527744327373291".into()),),
+            (0,  ("0.0".into(), "99.70093613678094097571666372594".into()),),
+            (1,  ("0.0".into(), "-183.0878169087836963770976657747".into()),),
         ],
         N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
+
     );
 }

--- a/tests/integral_evaluation_freeform_tests.rs
+++ b/tests/integral_evaluation_freeform_tests.rs
@@ -1,0 +1,78 @@
+mod test_utils;
+use vakint::{
+    utils::simplify_real, EvaluationMethod, EvaluationOrder, FMFTOptions, LoopNormalizationFactor,
+    MATADOptions,
+};
+
+use std::vec;
+
+use log::debug;
+use std::collections::HashMap;
+use symbolica::{
+    atom::AtomCore,
+    domains::{float::NumericalFloatLike, rational::Fraction},
+    parse,
+};
+use test_utils::{compare_numerical_output, compare_output, get_vakint};
+use vakint::{Vakint, VakintSettings};
+
+use crate::test_utils::compare_vakint_evaluation_vs_reference;
+use vakint::{externals_from_f64, params_from_f64, vakint_parse};
+
+const N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS: u32 = 32;
+
+#[test_log::test]
+fn test_integrate_1l_decorated_indices_alphaloop() {
+    #[rustfmt::skip]
+    Vakint::initialize_vakint_symbols();
+    compare_vakint_evaluation_vs_reference(
+        VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::MSbar,..VakintSettings::default()},
+        EvaluationOrder::alphaloop_only(),
+        parse!(
+            "( vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(8,user_space::mink4(4,77)) ) \
+             * vk::topo( vk::prop(9,vk::edge(66,66),vk::k(3),user_space::MUVsq,1 ))\
+            ")
+        .unwrap()
+        .as_view(),
+        params_from_f64(&[
+            ("user_space::MUVsq".into(), 1.0), ("vk::mursq".into(), 1.0),
+            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0)
+            ].iter().cloned().collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
+        HashMap::default(),
+        vec![
+            (-1, ("0.0".into(), "2.467401100272339654708622749969".into()),),
+            (0,  ("0.0".into(), "-5.368458141238928322097907419453".into()),),
+            (1,  ("0.0".into(), "9.411704244710969435114178881646".into()),),
+        ],
+        N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
+    );
+}
+
+#[test_log::test]
+fn test_integrate_1l_decorated_indices_matad() {
+    #[rustfmt::skip]
+    Vakint::initialize_vakint_symbols();
+    compare_vakint_evaluation_vs_reference(
+        VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::pySecDec,..VakintSettings::default()},
+        EvaluationOrder::matad_only(None),
+        parse!(
+            "( vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(8,user_space::mink4(4,77)) ) \
+             * vk::topo( vk::prop(9,vk::edge(66,66),vk::k(3),user_space::MUVsq,1 ))\
+            ")
+        .unwrap()
+        .as_view(),
+        params_from_f64(&[
+            ("user_space::MUVsq".into(), 1.0), ("vk::mursq".into(), 1.0),
+            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0)
+            ].iter().cloned().collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
+        HashMap::default(),
+        vec![
+            (-1, ("0.0".into(), "2.467401100272339654708622749969".into()),),
+            (0,  ("0.0".into(), "-5.368458141238928322097907419453".into()),),
+            (1,  ("0.0".into(), "9.411704244710969435114178881646".into()),),
+        ],
+        N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
+    );
+}

--- a/tests/integral_evaluation_freeform_tests.rs
+++ b/tests/integral_evaluation_freeform_tests.rs
@@ -1,23 +1,13 @@
 mod test_utils;
-use vakint::{
-    utils::simplify_real, EvaluationMethod, EvaluationOrder, FMFTOptions, LoopNormalizationFactor,
-    MATADOptions, PySecDecOptions,
-};
+use vakint::{EvaluationMethod, EvaluationOrder, LoopNormalizationFactor, PySecDecOptions};
 
 use std::vec;
 
-use log::debug;
-use std::collections::HashMap;
-use symbolica::{
-    atom::AtomCore,
-    domains::{float::NumericalFloatLike, rational::Fraction},
-    parse,
-};
-use test_utils::{compare_numerical_output, compare_output, get_vakint};
+use symbolica::parse;
 use vakint::{Vakint, VakintSettings};
 
 use crate::test_utils::compare_vakint_evaluation_vs_reference;
-use vakint::{externals_from_f64, params_from_f64, vakint_parse};
+use vakint::{externals_from_f64, params_from_f64};
 
 const N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS: u32 = 32;
 

--- a/tests/integral_evaluation_freeform_tests.rs
+++ b/tests/integral_evaluation_freeform_tests.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 use vakint::{
     utils::simplify_real, EvaluationMethod, EvaluationOrder, FMFTOptions, LoopNormalizationFactor,
-    MATADOptions,
+    MATADOptions, PySecDecOptions,
 };
 
 use std::vec;
@@ -20,6 +20,10 @@ use crate::test_utils::compare_vakint_evaluation_vs_reference;
 use vakint::{externals_from_f64, params_from_f64, vakint_parse};
 
 const N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS: u32 = 32;
+
+const N_DIGITS_PYSECDEC_EVALUATION_FOR_TESTS: u32 = 10;
+// PySecDec QMC is often very optimistic
+const MAX_PULL: f64 = 1.0e99;
 
 #[test_log::test]
 fn test_integrate_1l_decorated_indices_alphaloop() {
@@ -61,7 +65,7 @@ fn test_integrate_1l_decorated_indices_matad() {
     #[rustfmt::skip]
     Vakint::initialize_vakint_symbols();
     compare_vakint_evaluation_vs_reference(
-        VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::pySecDec,..VakintSettings::default()},
+        VakintSettings{number_of_terms_in_epsilon_expansion: 3, integral_normalization_factor: LoopNormalizationFactor::MSbar,..VakintSettings::default()},
         EvaluationOrder::matad_only(None),
         parse!(
             "( user_space::sigma(user_space::some_args)*vk::p(1,user_space::mink4(4,33))*vk::p(2,user_space::mink4(4,33))*vk::p(1,user_space::mink4(4,11))*vk::p(2,user_space::mink4(4,22))+vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(1,user_space::mink4(4,77)) ) \
@@ -89,5 +93,84 @@ fn test_integrate_1l_decorated_indices_matad() {
         ],
         N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
 
+    );
+}
+
+#[test_log::test]
+fn test_integrate_1l_decorated_indices_fmft() {
+    #[rustfmt::skip]
+    Vakint::initialize_vakint_symbols();
+    compare_vakint_evaluation_vs_reference(
+        VakintSettings{number_of_terms_in_epsilon_expansion: 5, integral_normalization_factor: LoopNormalizationFactor::MSbar,..VakintSettings::default()},
+        EvaluationOrder::fmft_only(None),
+        parse!(
+            "( user_space::sigma(user_space::some_args)*vk::p(1,user_space::mink4(4,33))*vk::p(2,user_space::mink4(4,33))*vk::p(1,user_space::mink4(4,11))*vk::p(2,user_space::mink4(4,22))+vk::k(3,user_space::mink4(4,11))*vk::k(3,user_space::mink4(4,22)) + vk::k(3,user_space::mink4(4,77))*vk::p(1,user_space::mink4(4,77)) ) \
+             * vk::topo( 
+                  vk::prop(9,vk::edge(66,66),vk::k(1),user_space::MUVsq,1 )
+                * vk::prop(9,vk::edge(66,66),vk::k(2),user_space::MUVsq,1 )
+                * vk::prop(9,vk::edge(66,66),vk::k(3),user_space::MUVsq,1 )
+                * vk::prop(9,vk::edge(66,66),vk::k(4),user_space::MUVsq,1 )
+            )\
+            ")
+        .unwrap()
+        .as_view(),
+        params_from_f64(&[
+            ("user_space::MUVsq".into(), 1.0), ("vk::mursq".into(), 1.0),
+            ("vk::g(user_space::mink4(4,22),user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(1,user_space::mink4(4,11))".into(), 1.0),
+            ("vk::p(2,user_space::mink4(4,22))".into(), 1.0),
+            ("user_space::sigma(user_space::some_args)".into(), 1.0),
+            ].iter().cloned().collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
+        externals_from_f64(
+        &(1..=2)
+            .map(|i| (i, (0.17*((i+1) as f64), 0.4*((i+2) as f64), 0.3*((i+3) as f64), 0.12*((i+4) as f64))))
+            .collect(),
+            N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS),
+        vec![
+            (-4, ("-35378.93674652074486878056225484".into(), "0.0".into()),),
+            (-3,  ("379847.4112339445643392527721787".into(), "0.0".into()),),
+            (-2,  ("-2225660.681830551493330196973382".into(), "0.0".into()),),
+            (-1,  ("9310322.197027486227836524560952".into(), "0.0".into()),),
+            (0,  ("-31010419.86210674125026829677739".into(), "0.0".into()),),
+        ],
+        N_DIGITS_ANLYTICAL_EVALUATION_FOR_TESTS, 1.0
+
+    );
+}
+
+#[test_log::test]
+fn test_integrate_1l_decorated_indices_pysecdec() {
+    #[rustfmt::skip]
+    compare_vakint_evaluation_vs_reference(
+        VakintSettings{number_of_terms_in_epsilon_expansion: 5, integral_normalization_factor: LoopNormalizationFactor::MSbar, ..VakintSettings::default()},
+        EvaluationOrder(vec![EvaluationMethod::PySecDec(PySecDecOptions { reuse_existing_output: Some("./tests_workspace/test_integrate_1l_decorated_indices_pysecdec".into()) ,..PySecDecOptions::default() })]),
+        parse!(
+            "(user_space::sigma*vk::k(1,user_space::mink4(4,11))*vk::p(1,user_space::mink4(4,11))*vk::k(1,user_space::mink4(4,12))*vk::p(1,user_space::mink4(4,12)))*vk::topo(\
+                vk::prop(1,vk::edge(1,1),vk::k(1),user_space::muvsq,2)\
+             )"
+        )
+        .unwrap()
+        .as_view(),
+        // Masses chosen equal on purpose here so as to have a reliable target analytical result
+        params_from_f64(&[
+            ("user_space::muvsq".into(), 1.0), 
+            ("vk::mursq".into(), 1.0),
+            ("user_space::sigma".into(), 1.0)
+            ].iter().cloned().collect(),
+            N_DIGITS_PYSECDEC_EVALUATION_FOR_TESTS),
+        externals_from_f64(
+        &(1..=1)
+            .map(|i| (i, (0.17*((i+1) as f64), 0.4*((i+2) as f64), 0.3*((i+3) as f64), 0.12*((i+4) as f64))))
+            .collect(),
+            N_DIGITS_PYSECDEC_EVALUATION_FOR_TESTS),
+        vec![
+            (-1, ("0.0".into(),  "-15.41829599538179739876641630989".into()),),
+            (0,  ("0.0".into(),   "41.25556923066471696715797280407".into()),),
+            (1,  ("0.0".into(),  "-75.58506810083682014451198579381".into()),),
+            (2,  ("0.0".into(),   "104.8268973321405776943695037314".into()),),
+            (3,  ("0.0".into(),  "-130.2125934660588794479583559489".into()),),
+        ],
+        N_DIGITS_PYSECDEC_EVALUATION_FOR_TESTS, MAX_PULL
     );
 }

--- a/tests/integral_evaluation_pysecdec_tests.rs
+++ b/tests/integral_evaluation_pysecdec_tests.rs
@@ -80,14 +80,14 @@ fn test_integrate_1l_cross_product_with_additional_symbols_numerator() {
         VakintSettings{number_of_terms_in_epsilon_expansion: 5, integral_normalization_factor: LoopNormalizationFactor::MSbar, ..VakintSettings::default()},
         EvaluationOrder(vec![EvaluationMethod::PySecDec(PySecDecOptions { reuse_existing_output: Some("./tests_workspace/test_integrate_1l_cross_product_additional_symbols_numerator".into()) ,..PySecDecOptions::default() })]),
         vakint_parse!(
-            "(A*k(1,11)*p(1,11)*k(1,12)*p(1,12)+B)*topo(\
+            "(user_space::A*k(1,11)*p(1,11)*k(1,12)*p(1,12)+user_space::B)*topo(\
                 prop(1,edge(1,1),k(1),muvsq,2)\
              )"
         )
         .unwrap()
         .as_view(),
         // Masses chosen equal on purpose here so as to have a reliable target analytical result
-        params_from_f64(&[("muvsq".into(), 1.0), ("mursq".into(), 1.0), ("A".into(), 3.0), ("B".into(), 4.0)].iter().cloned().collect(),
+        params_from_f64(&[("muvsq".into(), 1.0), ("mursq".into(), 1.0), ("user_space::A".into(), 3.0), ("user_space::B".into(), 4.0)].iter().cloned().collect(),
             N_DIGITS_PYSECDEC_EVALUATION_FOR_TESTS),
         externals_from_f64(
         &(1..=1)
@@ -355,9 +355,9 @@ fn test_integrate_4l_clover_with_numerator() {
             PySecDecOptions{ relative_precision: 1e-8, min_n_evals: 10_000_000, max_n_evals: 100_000_000, reuse_existing_output: Some("./tests_workspace/test_integrate_4l_clover_with_numerator".into()), ..PySecDecOptions::default()} )]),
         vakint_parse!(
             "( 
-                A * k(1,11)*k(2,11)*k(1,22)*k(2,22)
-              + B * p(1,11)*k(3,11)*k(3,22)*p(2,22)
-              + C * p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
+                user_space::A * k(1,11)*k(2,11)*k(1,22)*k(2,22)
+              + user_space::B * p(1,11)*k(3,11)*k(3,22)*p(2,22)
+              + user_space::C * p(1,11)*p(2,11)*(k(2,22)+k(1,22))*k(2,22) 
            )*topo(
               prop(1, edge(1, 1), k(1), muvsq, 2)*\
               prop(2, edge(1, 1), k(2), muvsq, 1)*\
@@ -368,7 +368,7 @@ fn test_integrate_4l_clover_with_numerator() {
         .unwrap()
         .as_view(),
         // Masses chosen equal on purpose here so as to have a reliable target analytical result
-        params_from_f64(&[("muvsq".into(), 0.3), ("mursq".into(), 0.7), ("A".into(), 3.0), ("B".into(), 4.0), ("C".into(), 5.0)].iter().cloned().collect(),
+        params_from_f64(&[("muvsq".into(), 0.3), ("mursq".into(), 0.7), ("user_space::A".into(), 3.0), ("user_space::B".into(), 4.0), ("user_space::C".into(), 5.0)].iter().cloned().collect(),
             4),
         externals_from_f64(
             &(1..=2)

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -364,7 +364,7 @@ pub fn compare_vakint_evaluation_vs_reference(
     let mut vakint_settings = VakintSettings {
         allow_unknown_integrals: true,
         use_dot_product_notation: true,
-        mu_r_sq_symbol: "mursq".into(),
+        mu_r_sq_symbol: "vk::mursq".into(),
         run_time_decimal_precision: prec,
         evaluation_order: mod_evaluation_order.clone(),
         ..vakint_default_settings


### PR DESCRIPTION
Support for decorated indices work throughout vakint.
Namespaces are no longer erased. 
Coefficients can be arbitrary symbolical expressions for all evaluation methods, except in pysecdec where they cannot contain functions.